### PR TITLE
configured a netlify.toml file to handle routing when deployed

### DIFF
--- a/frontend-react/netlify.toml
+++ b/frontend-react/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
added src/netlify.toml

previous bug: when the site is published using netlify, the router doesn't work properly (everything except the root path becomes 404 not found)